### PR TITLE
Add support stages for sls-deployment-bucket

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,12 +20,7 @@ class DeploymentBucketPlugin {
       return;
     }
 
-    if (this.deploymentBucket.name) {
-      this.config.versioning = get(this.config, 'versioning', false)
-      this.config.policy = get(this.config, 'policy', undefined)
-
-      this.hooks['before:package:setupProviderConfiguration'] = this.applyDeploymentBucket.bind(this)
-    }
+    this.hooks['before:package:setupProviderConfiguration'] = this.applyDeploymentBucket.bind(this)
   }
 
   async bucketExists(name) {
@@ -135,6 +130,14 @@ class DeploymentBucketPlugin {
   }
 
   async applyDeploymentBucket() {
+    if (!this.deploymentBucket.name) {
+      this.serverless.cli.log('Deployment bucket name is empty')
+      return;
+    }
+
+    this.config.versioning = get(this.config, 'versioning', false)
+    this.config.policy = get(this.config, 'policy', undefined)
+
     try {
       if (await this.bucketExists(this.deploymentBucket.name)) {
         this.serverless.cli.log(`Using deployment bucket '${this.deploymentBucket.name}'`)

--- a/lib/index.spec.js
+++ b/lib/index.spec.js
@@ -38,30 +38,36 @@ describe('DeploymentBucketPlugin', () => {
       expect(plugin.deploymentBucket).toEqual({})
     })
 
-    it('should default to empty config if missing object "custom"', () => {
+    it('should default to empty config if missing object "custom"', async () => {
       serverless.service.custom = undefined
       plugin = new DeploymentBucketPlugin(serverless, options)
 
+      await plugin.applyDeploymentBucket()
+
       expect(plugin.config).toEqual({})
     })
 
-    it('should default to empty config if missing object "custom.deploymentBucket"', () => {
+    it('should default to empty config if missing object "custom.deploymentBucket"', async () => {
       serverless.service.custom = {}
       plugin = new DeploymentBucketPlugin(serverless, options)
 
+      await plugin.applyDeploymentBucket()
+
       expect(plugin.config).toEqual({})
     })
 
-    it('should default to empty config if null object "custom.deploymentBucket"', () => {
+    it('should default to empty config if null object "custom.deploymentBucket"', async () => {
       serverless.service.custom = {
         deploymentBucket: null
       }
       plugin = new DeploymentBucketPlugin(serverless, options)
 
+      await plugin.applyDeploymentBucket()
+
       expect(plugin.config).toEqual({})
     })
 
-    it('should default versioning to false if missing property "custom.deploymentBucket.versioning"', () => {
+    it('should default versioning to false if missing property "custom.deploymentBucket.versioning"', async () => {
       serverless.service.provider.deploymentBucketObject = {
         name: 'some-bucket'
       }
@@ -70,23 +76,9 @@ describe('DeploymentBucketPlugin', () => {
       }
       plugin = new DeploymentBucketPlugin(serverless, options)
 
+      await plugin.applyDeploymentBucket()
+
       expect(plugin.config.versioning).toEqual(false)
-    })
-
-    it('should not set hooks if missing property "custom.deploymentBucket.name"', () => {
-      serverless.service.provider.deploymentBucketObject = {}
-      plugin = new DeploymentBucketPlugin(serverless, options)
-
-      expect(plugin.hooks).not.toHaveProperty('before:package:setupProviderConfiguration')
-    })
-
-    it('should not set hooks if empty property "custom.deploymentBucket.name"', () => {
-      serverless.service.provider.deploymentBucketObject = {
-        name: ''
-      }
-      plugin = new DeploymentBucketPlugin(serverless, options)
-
-      expect(plugin.hooks).not.toHaveProperty('before:package:setupProviderConfiguration')
     })
   })
 
@@ -140,6 +132,26 @@ describe('DeploymentBucketPlugin', () => {
       }
 
       plugin = new DeploymentBucketPlugin(serverless, options)
+    })
+
+    it('should log info when "custom.deploymentBucket.name" is missing', async () => {
+      serverless.service.provider.deploymentBucketObject = {}
+      plugin = new DeploymentBucketPlugin(serverless, options)
+
+      await plugin.applyDeploymentBucket()
+
+      expect(plugin.serverless.cli.log).toHaveBeenCalledWith(expect.stringContaining('Deployment bucket name is empty'))
+    })
+
+    it('should log info when "custom.deploymentBucket.name" is empty', async () => {
+      serverless.service.provider.deploymentBucketObject = {
+        name: ''
+      }
+      plugin = new DeploymentBucketPlugin(serverless, options)
+
+      await plugin.applyDeploymentBucket()
+
+      expect(plugin.serverless.cli.log).toHaveBeenCalledWith(expect.stringContaining('Deployment bucket name is empty'))
     })
 
     it('should log info when using existing deployment bucket', async () => {


### PR DESCRIPTION
Hi,
This is my first modification in any serverless plugin :) (inc. NodeJS).

Today I'm trying figureout how to customize `serverless-deployment-bucket` to support name depends on diffrent stages name or skip for some stage. Below example of serverless.yml that doesn't work well with the plugin:

```yaml
service: my-service

plugins:
  - serverless-deployment-bucket

custom:
  stages:
    local:
      deploymentBucket: sls-localstack
    dev:
      deploymentBucket: sls-deployment-bucket-${self:provider.stage}
    prod:
      deploymentBucket: null

  deploymentBucket:
    versioning: true

provider:
  name: aws
  runtime: nodejs12.x
  stage: ${opt:stage, 'local'}

  deploymentBucket:
    name: ${self:custom.stages.${self:provider.stage}}

resources:
  Resources:
    NewResource:
      Type: AWS::S3::Bucket
      Properties:
        BucketName: sample-s3-123mnb321
```

The error:
```
 sls deploy -v
Serverless: Load command interactiveCli
Serverless: Load command config
Serverless: Load command config:credentials
Serverless: Load command create
Serverless: Load command install
Serverless: Load command package
Serverless: Load command deploy
Serverless: Load command deploy:function
Serverless: Load command deploy:list
Serverless: Load command deploy:list:functions
Serverless: Load command invoke
Serverless: Load command invoke:local
Serverless: Load command info
Serverless: Load command logs
Serverless: Load command metrics
Serverless: Load command print
Serverless: Load command remove
Serverless: Load command rollback
Serverless: Load command rollback:function
Serverless: Load command slstats
Serverless: Load command plugin
Serverless: Load command plugin
Serverless: Load command plugin:install
Serverless: Load command plugin
Serverless: Load command plugin:uninstall
Serverless: Load command plugin
Serverless: Load command plugin:list
Serverless: Load command plugin
Serverless: Load command plugin:search
Serverless: Load command config
Serverless: Load command config:credentials
Serverless: Load command rollback
Serverless: Load command rollback:function
Serverless: Load command upgrade
Serverless: Load command uninstall
Serverless: Load command deploy
Serverless: Load command login
Serverless: Load command logout
Serverless: Load command generate-event
Serverless: Load command test
Serverless: Load command dashboard
Serverless: Load command output
Serverless: Load command output:get
Serverless: Load command output:list
Serverless: Load command param
Serverless: Load command param:get
Serverless: Load command param:list
Serverless: Invoke deploy
Serverless: Invoke package
Serverless: Invoke aws:common:validate
Serverless: Using serverless-localstack
Serverless: Warning: Unable to find plugin named: TypeScriptPlugin
Serverless: Invoke aws:common:cleanupTempDir

  Serverless Error ---------------------------------------

  ServerlessError: Bucket name cannot contain uppercase letters. [object Object]
```

Digging into plugin I've put few console.logs and I saw that one of log in constructor of this plugin doesn't resolve serverless variables.

Modified code:
```nodejs
if (this.config.enabled !== undefined && this.config.enabled === false) {
      return;
    }

    console.log(`---->DeploymentBucketName: ${this.deploymentBucket.name}`)
    
    if (this.deploymentBucket.name) {
      this.config.versioning = get(this.config, 'versioning', false)
      this.config.policy = get(this.config, 'policy', undefined)
}
```

Result:

```
Serverless: Load command upgrade
Serverless: Load command uninstall
---->DeploymentBucketName: ${self:custom.stages.${self:provider.stage}}
Serverless: Load command login
Serverless: Load command logout
```
So I move this into `applyDeploymentBucket` and works well. Also I've added new custom property `stages` that plugin should be enabled.

I only need some help to make tests for this changes. I'm stuck on passing stage name :/
