### PR TITLE
Add option to enable S3 acceleration to bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,15 @@ Optionally add custom configuration properties:
 custom:
   deploymentBucket:
     versioning: true
+    accelerate: true
 ```
 
-| Property     | Required | Type      | Default | Description                                |
-|--------------|----------|-----------|---------|--------------------------------------------|
-| `versioning` |  `false` | `boolean` | `false` | Enable versioning on the deployment bucket |
-| `enabled`    |  `false` | `boolean` | `true`  | Enable this plugin                         |
-| `policy`     |  `false` | `string`  |         | Bucket policy as JSON                      |
+| Property     | Required | Type      | Default | Description                                  |
+|--------------|----------|-----------|---------|----------------------------------------------|
+| `versioning` |  `false` | `boolean` | `false` | Enable versioning on the deployment bucket   |
+| `accelerate` |  `false` | `boolean` | `false` | Enable acceleration on the deployment bucket |
+| `enabled`    |  `false` | `boolean` | `true`  | Enable this plugin                           |
+| `policy`     |  `false` | `string`  |         | Bucket policy as JSON                        |
 
 ## Usage
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,6 +22,7 @@ class DeploymentBucketPlugin {
 
     if (this.deploymentBucket.name) {
       this.config.versioning = get(this.config, 'versioning', false)
+      this.config.accelerate = get(this.config, 'accelerate', false)
       this.config.policy = get(this.config, 'policy', undefined)
 
       const serverlessCommand = get(this.serverless, 'processedInput.commands', [])
@@ -129,6 +130,34 @@ class DeploymentBucketPlugin {
     return await this.provider.request('S3', 'putBucketVersioning', params)
   }
 
+  async hasBucketAcceleration(name) {
+    const params = {
+      Bucket: name
+    };
+
+    try {
+      const response = await this.provider.request('S3', 'getBucketAccelerateConfiguration', params)
+      if (response.Status && response.Status == 'Enabled') {
+        return true
+      }
+
+      return false
+    } catch (e) {
+      return false
+    }
+  }
+
+  async putBucketAcceleration(name, status) {
+    const params = {
+      Bucket: name,
+      AccelerateConfiguration: {
+        Status: status ? 'Enabled' : 'Suspended'
+      }
+    };
+
+    return await this.provider.request('S3', 'putBucketAccelerateConfiguration', params)
+  }
+
   async putBucketPolicy(name, policy) {
     const params = {
       Bucket: name,
@@ -163,6 +192,16 @@ class DeploymentBucketPlugin {
           this.serverless.cli.log('Enabled versioning on deployment bucket')
         } else {
           this.serverless.cli.log('Suspended versioning on deployment bucket')
+        }
+      }
+
+      if ((await this.hasBucketAcceleration(this.deploymentBucket.name)) != this.config.accelerate) {
+        await this.putBucketAcceleration(this.deploymentBucket.name, this.config.accelerate)
+
+        if (this.config.accelerate) {
+          this.serverless.cli.log('Enabled acceleration on deployment bucket')
+        } else {
+          this.serverless.cli.log('Suspended acceleration on deployment bucket')
         }
       }
 

--- a/lib/index.spec.js
+++ b/lib/index.spec.js
@@ -73,6 +73,18 @@ describe('DeploymentBucketPlugin', () => {
       expect(plugin.config.versioning).toEqual(false)
     })
 
+    it('should default acceleration to false if missing property "custom.deploymentBucket.acceleration"', () => {
+      serverless.service.provider.deploymentBucketObject = {
+        name: 'some-bucket'
+      }
+      serverless.service.custom = {
+        deploymentBucket: {}
+      }
+      plugin = new DeploymentBucketPlugin(serverless, options)
+
+      expect(plugin.config.accelerate).toEqual(false)
+    })
+
     it('should not set hooks if missing property "custom.deploymentBucket.name"', () => {
       serverless.service.provider.deploymentBucketObject = {}
       plugin = new DeploymentBucketPlugin(serverless, options)
@@ -157,7 +169,8 @@ describe('DeploymentBucketPlugin', () => {
       }
       serverless.service.custom = {
         deploymentBucket: {
-          versioning: true
+          versioning: true,
+          accelerate: true
         }
       }
 
@@ -218,6 +231,39 @@ describe('DeploymentBucketPlugin', () => {
       expect(plugin.serverless.cli.log).toHaveBeenCalledWith(expect.stringContaining('Suspended versioning'))
     })
 
+    it('should log info when acceleration is applied to deployment bucket', async () => {
+      plugin.provider.request
+        .mockResolvedValueOnce({}) // S3.headBucket()
+        .mockResolvedValueOnce({}) // S3.getBucketEncryption()
+        .mockResolvedValueOnce({
+          Status: 'Enabled'
+        }) // S3.getBucketVersioning()
+        .mockResolvedValueOnce({
+          Status: 'Suspended'
+        }) // S3.getBucketAccelerateConfiguration()
+
+      await plugin.applyDeploymentBucket()
+
+      expect(plugin.serverless.cli.log).toHaveBeenCalledWith(expect.stringContaining('Enabled acceleration'))
+    })
+
+    it('should suspend acceleration when acceleration is not already suspended on deployment bucket', async () => {
+      plugin.config.accelerate = false
+      plugin.provider.request
+        .mockResolvedValueOnce({}) // S3.headBucket()
+        .mockResolvedValueOnce({}) // S3.getBucketEncryption()
+        .mockResolvedValueOnce({
+          Status: 'Enabled'
+        }) // S3.getBucketVersioning()
+        .mockResolvedValueOnce({
+          Status: 'Enabled'
+        }) // S3.getBucketAccelerateConfiguration()
+
+      await plugin.applyDeploymentBucket()
+
+      expect(plugin.serverless.cli.log).toHaveBeenCalledWith(expect.stringContaining('Suspended acceleration'))
+    })
+
     it('should log error when exception caught', async () => {
       const spy = jest.spyOn(console, 'error')
       const errorMessage = 'Some AWS provider error'
@@ -241,6 +287,22 @@ describe('DeploymentBucketPlugin', () => {
       await plugin.applyDeploymentBucket()
 
       expect(plugin.serverless.cli.log).not.toHaveBeenCalledWith(expect.stringContaining('Enabled versioning'))
+    })
+
+    it('should not enable acceleration when acceleration is already enabled on deployment bucket', async () => {
+      plugin.provider.request
+        .mockResolvedValueOnce({}) // S3.headBucket()
+        .mockResolvedValueOnce({}) // S3.getBucketEncryption()
+        .mockResolvedValueOnce({
+          Status: 'Enabled'
+        }) // S3.getBucketVersioning()
+        .mockResolvedValueOnce({
+          Status: 'Enabled'
+        }) // S3.getBucketAccelerateConfiguration()
+
+      await plugin.applyDeploymentBucket()
+
+      expect(plugin.serverless.cli.log).not.toHaveBeenCalledWith(expect.stringContaining('Enabled acceleration'))
     })
 
     it('should not apply SSE if not configured on provider', async () => {


### PR DESCRIPTION
This PR adds an option to enable S3 acceleration for the created bucket. It behaves much like the optional parameter for versioning.

It should resolve https://github.com/MikeSouza/serverless-deployment-bucket/issues/19.