### PR TITLE
Fix for inital bucket condition with no tags

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -229,6 +229,7 @@ class DeploymentBucketPlugin {
 
         await this.createBucket(this.deploymentBucket.name)
         await this.waitFor(this.deploymentBucket.name, 'bucketExists')
+        await this.updateBucketTags(this.deploymentBucket.name, this.config.tags)
       }
 
       if (this.deploymentBucket.serverSideEncryption) {


### PR DESCRIPTION
Hey when working with the plugin I noticed that there was an error being thrown and silenced: 

`providerError: NoSuchTagSet: The TagSet does not exist`

This occurs when the plugin is attempting gather tags and none exist, so it will never add tags even if they have changed. 

I put a quick fix up which at least allows tags to be added initially for the bucket. I can add some more error handling edge case stuff if needed.  