### PR TITLE
Update to support custom KMS Keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,24 @@ Serverless Error ---------------------------------------
   Could not locate deployment bucket. Error: The specified bucket does not exist
 ```
 
-This plugin will create your custom deployment bucket if it doesn't exist, and optionally configure the deployment bucket to apply server-side encryption by default on objects, regardless of whether the bucket was created by this plugin and as long as you configure the provider with `serverSideEncryption: AES256`.
+This plugin will create your custom deployment bucket if it doesn't exist, and optionally configure the deployment bucket to apply server-side encryption. To support the [AWS S3 API](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketEncryption.html) for encryption you can configure this plugin with the following:
+
+For AES256 (AES256 or AES) server side encryption support:
+
+```yaml
+  deploymentBucket:
+    name: your-custom-deployment-bucket
+    serverSideEncryption: AES256
+```
+
+For KMS (aws:kms or KMS) server side encryption support:
+
+```yaml
+  deploymentBucket:
+    name: your-custom-deployment-bucket
+    serverSideEncryption: KMS
+    kmsKeyID: your-kms-key-id
+```
 
 This plugin also provides the optional ability to enable versioning of bucket objects, however this is not enabled by default since Serverless tends to keep its own copies and versions of state.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Serverless Error ---------------------------------------
 
 This plugin will create your custom deployment bucket if it doesn't exist, and optionally configure the deployment bucket to apply server-side encryption. To support the [AWS S3 API](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketEncryption.html) for encryption you can configure this plugin with the following:
 
-For AES256 (AES256 or AES) server side encryption support:
+For `AES256` server side encryption support:
 
 ```yaml
   deploymentBucket:
@@ -27,12 +27,12 @@ For AES256 (AES256 or AES) server side encryption support:
     serverSideEncryption: AES256
 ```
 
-For KMS (aws:kms or KMS) server side encryption support:
+For `aws:kms` server side encryption support:
 
 ```yaml
   deploymentBucket:
     name: your-custom-deployment-bucket
-    serverSideEncryption: KMS
+    serverSideEncryption: aws:kms
     kmsKeyID: your-kms-key-id
 ```
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,6 +14,32 @@ const getPublicAccessBlock = block => block === true
 class DeploymentBucketPlugin {
   constructor(serverless, options) {
     this.serverless = serverless
+
+    const TopLevelPropSchema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        serverSideEncryption: { type: 'string' },
+        kmsKeyID: { type: 'string' },
+      },
+      required: ['name']
+    }
+
+    const CustomPropSchema = {
+      type: 'object',
+      properties: {
+        enabled: { type: 'boolean' },
+        versioning: { type: 'boolean' },
+        accelerate: { type: 'boolean' },
+        policy: { type: 'any' },
+        tags: { type: 'any' },
+        blockPublicAccess: { type: 'boolean' },
+      },
+    }
+
+    serverless.configSchemaHandler.defineTopLevelProperty('deploymentBucket', TopLevelPropSchema);
+    serverless.configSchemaHandler.defineCustomProperties(CustomPropSchema);
+
     this.provider = this.serverless.providers.aws
 
     const deploymentBucketProp = util.deploymentBucketProperty(this.serverless.version)
@@ -236,11 +262,11 @@ class DeploymentBucketPlugin {
 
       if (this.deploymentBucket.serverSideEncryption) {
         if (!(await this.hasBucketEncryption(this.deploymentBucket.name))) {
-          if (this.deploymentBucket.serverSideEncryption === "aws:kms" || this.deploymentBucket.serverSideEncryption === "KMS") {
+          if (this.deploymentBucket.serverSideEncryption === "aws:kms") {
             await this.putBucketEncryption(this.deploymentBucket.name, this.deploymentBucket.serverSideEncryption, this.deploymentBucket.kmsKeyID)
           }
 
-          if (this.deploymentBucket.serverSideEncryption === "AES256" || this.deploymentBucket.serverSideEncryption === "AES") {
+          if (this.deploymentBucket.serverSideEncryption === "AES256") {
             await this.putBucketEncryption(this.deploymentBucket.name, this.deploymentBucket.serverSideEncryption)
           }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -238,14 +238,13 @@ class DeploymentBucketPlugin {
         if (!(await this.hasBucketEncryption(this.deploymentBucket.name))) {
           if (this.deploymentBucket.serverSideEncryption === "aws:kms" || this.deploymentBucket.serverSideEncryption === "KMS") {
             await this.putBucketEncryption(this.deploymentBucket.name, this.deploymentBucket.serverSideEncryption, this.deploymentBucket.kmsKeyID)
-            this.serverless.cli.log(`Applied KMS SSE (${this.deploymentBucket.serverSideEncryption}) to deployment bucket`)
           }
 
           if (this.deploymentBucket.serverSideEncryption === "AES256" || this.deploymentBucket.serverSideEncryption === "AES") {
             await this.putBucketEncryption(this.deploymentBucket.name, this.deploymentBucket.serverSideEncryption)
-            this.serverless.cli.log(`Applied AES SSE (${this.deploymentBucket.serverSideEncryption}) to deployment bucket`)
           }
 
+          this.serverless.cli.log(`Applied SSE (${this.deploymentBucket.serverSideEncryption}) to deployment bucket`)
         }
       }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -236,9 +236,16 @@ class DeploymentBucketPlugin {
 
       if (this.deploymentBucket.serverSideEncryption) {
         if (!(await this.hasBucketEncryption(this.deploymentBucket.name))) {
-          await this.putBucketEncryption(this.deploymentBucket.name, this.deploymentBucket.serverSideEncryption)
+          if (this.deploymentBucket.serverSideEncryption === "aws:kms" || this.deploymentBucket.serverSideEncryption === "KMS") {
+            await this.putBucketEncryption(this.deploymentBucket.name, this.deploymentBucket.serverSideEncryption, this.deploymentBucket.kmsKeyID)
+            this.serverless.cli.log(`Applied KMS SSE (${this.deploymentBucket.serverSideEncryption}) to deployment bucket`)
+          }
 
-          this.serverless.cli.log(`Applied SSE (${this.deploymentBucket.serverSideEncryption}) to deployment bucket`)
+          if (this.deploymentBucket.serverSideEncryption === "AES256" || this.deploymentBucket.serverSideEncryption === "AES") {
+            await this.putBucketEncryption(this.deploymentBucket.name, this.deploymentBucket.serverSideEncryption)
+            this.serverless.cli.log(`Applied AES SSE (${this.deploymentBucket.serverSideEncryption}) to deployment bucket`)
+          }
+
         }
       }
 

--- a/lib/index.spec.js
+++ b/lib/index.spec.js
@@ -124,11 +124,30 @@ describe('DeploymentBucketPlugin', () => {
     })
   })
 
-  describe('with configuration', () => {
+  describe('with AES configuration', () => {
     beforeEach(() => {
       serverless.service.provider[deploymentBucketProp] = {
         name: 'some-bucket',
         serverSideEncryption: 'AES256'
+      }
+      plugin = new DeploymentBucketPlugin(serverless, options)
+    })
+
+    it('should set config', () => {
+      expect(plugin.config).toBeTruthy()
+    })
+
+    it('should set hooks', () => {
+      expect(plugin.hooks).toHaveProperty('before:aws:common:validate:validate')
+    })
+  })
+
+  describe('with KMS configuration', () => {
+    beforeEach(() => {
+      serverless.service.provider[deploymentBucketProp] = {
+        name: 'some-bucket',
+        serverSideEncryption: 'KMS',
+        kmsKeyID: 'some-key-id'
       }
       plugin = new DeploymentBucketPlugin(serverless, options)
     })

--- a/lib/index.spec.js
+++ b/lib/index.spec.js
@@ -124,7 +124,7 @@ describe('DeploymentBucketPlugin', () => {
     })
   })
 
-  describe('with AES configuration', () => {
+  describe('with AES256 configuration', () => {
     beforeEach(() => {
       serverless.service.provider[deploymentBucketProp] = {
         name: 'some-bucket',
@@ -146,7 +146,7 @@ describe('DeploymentBucketPlugin', () => {
     beforeEach(() => {
       serverless.service.provider[deploymentBucketProp] = {
         name: 'some-bucket',
-        serverSideEncryption: 'KMS',
+        serverSideEncryption: 'aws:kms',
         kmsKeyID: 'some-key-id'
       }
       plugin = new DeploymentBucketPlugin(serverless, options)


### PR DESCRIPTION
Closes #46

Adds better support for KMS
Following docs from here: https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketEncryption.html

AES256 or aws:kms are supported by the AWS API, I added KMS and AES to this plugin as supported options as well.