### PR TITLE
Add possibility to define deployment bucket access logs (#70)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ For `aws:kms` server side encryption support:
     name: your-custom-deployment-bucket
     serverSideEncryption: aws:kms
     kmsKeyID: your-kms-key-id
+    
+For bucket access logging support:
+
+```yaml
+  deploymentBucket:
+    name: your-custom-deployment-bucket
+    accessLog:
+      bucket: "the-already-existing-bucket"
+      prefix: "prefix-to-use-for-these-logs"
 ```
 
 This plugin also provides the optional ability to enable versioning of bucket objects, however this is not enabled by default since Serverless tends to keep its own copies and versions of state.

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,6 +29,7 @@ class DeploymentBucketPlugin {
 
     if (this.deploymentBucket.name) {
       this.config.versioning = get(this.config, 'versioning', false)
+      this.config.accessLog = get(this.config, 'accessLog', false)
       this.config.accelerate = get(this.config, 'accelerate', false)
       this.config.policy = get(this.config, 'policy', undefined)
       this.config.tags = util.filterValidBucketTags(get(this.config, 'tags', undefined))
@@ -128,6 +129,24 @@ class DeploymentBucketPlugin {
     }
   }
 
+  async shouldUpdateBucketAccessLogging (name, config) {
+    const params = {
+      Bucket: name
+    }
+
+    try {
+      const response = await this.provider.request('S3', 'getBucketLogging', params)
+      const loggingEnabledAndMatches = response.LoggingEnabled
+        && config.bucket === response.LoggingEnabled.TargetBucket
+        && config.prefix === response.LoggingEnabled.TargetPrefix
+
+      return !(loggingEnabledAndMatches || (!response.LoggingEnabled && !config));
+    } catch (e) {
+      this.serverless.cli.log('Failed to get bucket logging configuration', e)
+      return false;
+    }
+  }
+
   async putBucketVersioning(name, status) {
     const params = {
       Bucket: name,
@@ -139,7 +158,29 @@ class DeploymentBucketPlugin {
     return await this.provider.request('S3', 'putBucketVersioning', params)
   }
 
-  async hasBucketAcceleration(name) {
+  async putBucketAccessLogging (name, { bucket, prefix }) {
+    const params = bucket ? {
+      Bucket: name,
+      BucketLoggingStatus: {
+        LoggingEnabled: {
+          TargetBucket: bucket,
+          TargetPrefix: prefix
+        }
+      }
+    } : {
+      Bucket: name,
+      BucketLoggingStatus: {}
+    }
+    try {
+      return await this.provider.request('S3', 'putBucketLogging', params)
+    } catch (e) {
+      this.serverless.cli.log('Failed to put bucket logging configuration', e)
+      return false
+    }
+
+  }
+
+  async hasBucketAcceleration (name) {
     const params = {
       Bucket: name
     };
@@ -286,6 +327,17 @@ class DeploymentBucketPlugin {
         await this.updatePublicAccessBlock(this.deploymentBucket.name, this.config.blockPublicAccess)
         this.serverless.cli.log('Updated deployment bucket public access block')
       }
+
+      if ((await this.shouldUpdateBucketAccessLogging(this.deploymentBucket.name, this.config.accessLog))) {
+        await this.putBucketAccessLogging(this.deploymentBucket.name, this.config.accessLog)
+
+        if (this.config.accessLog) {
+          this.serverless.cli.log('Enabled access logging on deployment bucket')
+        } else {
+          this.serverless.cli.log('Suspended access logging on deployment bucket')
+        }
+      }
+
     } catch (e) {
       console.error(chalk.red(`\n-------- Deployment Bucket Error --------\n${e.message}`))
     }

--- a/lib/index.spec.js
+++ b/lib/index.spec.js
@@ -88,6 +88,18 @@ describe('DeploymentBucketPlugin', () => {
       expect(plugin.config.accelerate).toEqual(false)
     })
 
+    it('should default access logging to false if missing property "custom.deploymentBucket.accessLog"', () => {
+      serverless.service.provider[deploymentBucketProp] = {
+        name: 'some-bucket'
+      }
+      serverless.service.custom = {
+        deploymentBucket: {}
+      }
+      plugin = new DeploymentBucketPlugin(serverless, options)
+
+      expect(plugin.config.accessLog).toEqual(false)
+    })
+
     it('should not set hooks if missing property "custom.deploymentBucket.name"', () => {
       serverless.service.provider[deploymentBucketProp] = {}
       plugin = new DeploymentBucketPlugin(serverless, options)
@@ -703,6 +715,59 @@ describe('DeploymentBucketPlugin', () => {
       await plugin.applyDeploymentBucket()
 
       expect(plugin.serverless.cli.log).toHaveBeenCalledWith(expect.stringContaining('Updated deployment bucket public access block'))
+    })
+
+    it('should log info about addition when access logging is applied to deployment bucket', async () => {
+      plugin.config = {
+        ...plugin.config,
+        accelerate: false,
+        versioning: false,
+        policy: undefined,
+        tags: undefined,
+        blockPublicAccess: false,
+        accessLog: true
+      }
+
+      plugin.provider.request
+        .mockRejectedValueOnce({}) // S3.headBucket()
+        .mockResolvedValueOnce({}) // S3.createBucket()
+        .mockResolvedValueOnce({}) // S3.getBucketEncryption()
+        .mockResolvedValueOnce({}) // S3.getBucketVersioning()
+        .mockResolvedValueOnce({}) // S3.getBucketAccelerateConfiguration()
+        .mockResolvedValueOnce({}) // S3.getBucketTagging()
+        .mockResolvedValueOnce({}) // S3.deletePublicAccessBlock()
+        .mockResolvedValueOnce({LoggingEnabled: false}) // S3.getBucketLogging()
+        .mockResolvedValueOnce() // S3.putBucketAccessLogging()
+
+      await plugin.applyDeploymentBucket()
+
+      expect(plugin.serverless.cli.log).toHaveBeenCalledWith(expect.stringContaining('Enabled access logging on deployment bucket'))
+    })
+
+    it('should log info about removal when access logging is applied to deployment bucket', async () => {
+      plugin.config = {
+        ...plugin.config,
+        accelerate: false,
+        versioning: false,
+        policy: undefined,
+        tags: undefined,
+        blockPublicAccess: false,
+        accessLog: false
+      }
+
+      plugin.provider.request
+        .mockRejectedValueOnce({}) // S3.headBucket()
+        .mockResolvedValueOnce({}) // S3.createBucket()
+        .mockResolvedValueOnce({}) // S3.getBucketEncryption()
+        .mockResolvedValueOnce({}) // S3.getBucketVersioning()
+        .mockResolvedValueOnce({}) // S3.getBucketAccelerateConfiguration()
+        .mockResolvedValueOnce({}) // S3.getBucketTagging()
+        .mockResolvedValueOnce({}) // S3.deletePublicAccessBlock()
+        .mockResolvedValueOnce({ LoggingEnabled: { TargetBucket:'Bucket' }}) // S3.putBucketAccessLogging()
+
+      await plugin.applyDeploymentBucket()
+
+      expect(plugin.serverless.cli.log).toHaveBeenCalledWith(expect.stringContaining('Suspended access logging on deployment bucket'))
     })
   })
 })


### PR DESCRIPTION
* Add possibility to defined deployment bucket access logs

This PR adds an additional optional configuration block to enable Serverless deployment bucket access logs. The configuration is defined as an object that contains two properties: `bucket` and `prefix`.
* bucket: The name of the (already existing) logging bucket
* prefix: Prefix to be used within the bucket.

* Add missing mock to spec