### PR TITLE
fix: order mismatch between config and api

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,10 @@ const getPublicAccessBlock = block => block === true
   ? { BlockPublicAcls: true, BlockPublicPolicy: true, IgnorePublicAcls: true, RestrictPublicBuckets: true }
   : { BlockPublicAcls: false, BlockPublicPolicy: false, IgnorePublicAcls: false, RestrictPublicBuckets: false }
 
+const sortObject = obj => typeof obj === 'object'
+  ? Object.fromEntries(Object.entries(obj).sort())
+  : obj
+
 class DeploymentBucketPlugin {
   constructor(serverless, options) {
     this.serverless = serverless
@@ -242,7 +246,7 @@ class DeploymentBucketPlugin {
     try {
       const config = getPublicAccessBlock(blockPublicAccess)
       const response = await this.provider.request('S3', 'getPublicAccessBlock', { Bucket: name })
-      return response && JSON.stringify(response.PublicAccessBlockConfiguration) !== JSON.stringify(config)
+      return response && JSON.stringify(sortObject(response.PublicAccessBlockConfiguration)) !== JSON.stringify(sortObject(config))
     } catch (e) {
       return blockPublicAccess
     }

--- a/lib/index.spec.js
+++ b/lib/index.spec.js
@@ -631,7 +631,7 @@ describe('DeploymentBucketPlugin', () => {
         .mockResolvedValueOnce({}) // S3.getBucketAccelerateConfiguration()
         .mockResolvedValueOnce({
           PublicAccessBlockConfiguration: {
-            BlockPublicAcls: true, BlockPublicPolicy: true, IgnorePublicAcls: true, RestrictPublicBuckets: true
+            BlockPublicAcls: true, IgnorePublicAcls: true, BlockPublicPolicy: true, RestrictPublicBuckets: true
           }
         }) // S3.getPublicAccessBlock()
 


### PR DESCRIPTION
The S3 `getPublicAccessBlock` api  can return the aws config in a different order. This results in a perceived configuration mismatch and a unneeded `putPublicAccessBlock` on every deployment.

This change makes the comparison independent of order, by first sorting the configuration by name.